### PR TITLE
Small Py3 fix, and adds a helper method to write to the pasteboard

### DIFF
--- a/Lib/aicbTools.py
+++ b/Lib/aicbTools.py
@@ -139,6 +139,27 @@ def readAICBFromPasteboard():
     data = data.decode("utf-8")
     return data
 
+def writeAICBToPasteboard(data):
+    """
+    set the AICB data to the NSPasteboard
+    """
+    from AppKit import NSPasteboard, NSData
+    pb = NSPasteboard.generalPasteboard()
+    types = [
+        "CorePasteboardFlavorType 0x41494342",
+        "com.adobe.encapsulated-postscript"
+    ]
+    # clear pasteboard
+    pb.clearContents()
+    # convert to NSData and set to the pasteboard
+    try:
+        data = bytes(data, "utf-8") # Python 3
+    except:
+        data = bytes(data) # Python 2
+    nd = NSData.alloc().initWithBytes_length_(data, len(data))
+    for typ in types:
+        pb.setData_forType_(nd, typ)
+
 def _getRectTransform(rect1, rect2, fixedScale=None):
     """
     return an affine transform matrix

--- a/Lib/aicbTools.py
+++ b/Lib/aicbTools.py
@@ -136,7 +136,7 @@ def readAICBFromPasteboard():
             data = data.tobytes()
     except NameError:
         pass
-    data = str(data)
+    data = data.decode("utf-8")
     return data
 
 def _getRectTransform(rect1, rect2, fixedScale=None):


### PR DESCRIPTION
Decodes the clipboard data in a way that Python 2 and 3 can agree with, and adds a `writeAICBToPasteboard()` helper method.